### PR TITLE
FIX: publication video link

### DIFF
--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -188,7 +188,7 @@
   doi = {10.1109/TRO.2022.3197080},
   pdf      = {http://kavrakilab.org/publications/kingston2022-scaling-mmp.pdf},
   abstract = {Robotic manipulation is inherently continuous, but typically has an underlying discrete structure, such as if an object is grasped. Many problems like these are multi-modal, such as pick-and-place tasks where every object grasp and placement is a mode. Multi-modal problems require finding a sequence of transitions between modes - for example, a particular sequence of object picks and placements. However, many multi-modal planners fail to scale when motion planning is difficult (e.g., in clutter) or the task has a long horizon (e.g., rearrangement). This work presents solutions for multi-modal scalability in both these areas. For motion planning, we present an experience-based planning framework ALEF which reuses experience from similar modes both online and from training data. For task satisfaction, we present a layered planning approach that uses a discrete lead to bias search towards useful mode transitions, informed by weights over mode transitions. Together, these contributions enable multi-modal planners to tackle complex manipulation tasks that were previously infeasible or inefficient, and provide significant improvements in scenes with high-dimensional robots.},
-  video = {<https://player.vimeo.com/video/743110686?loop=1&color=ffffff&byline=0&portrait=0},
+  video = {https://player.vimeo.com/video/743110686?loop=1&color=ffffff&byline=0&portrait=0},
   selected = {true},
   preview = {r2_walking.jpg},
   projects = {long-horizon,constraints},


### PR DESCRIPTION
The video link for the paper "Scaling Multi-Modal Planning: Using Experience and Informing Discrete Search" under the "Publications" page does not work. It currently points to `https://commalab.org/publications/%3Chttps://player.vimeo.com/video/743110686?loop=1&color=ffffff&byline=0&portrait=0`, which is invalid.

The reason is likely because of the appearance of the `<` symbol before the URL inside the `_bibliography/papers.bib` file, which I removed. Unfortunately, I have not been able to test this locally on my end, but I am fairly certain that this is the problem, since other video links under the `_bibliography/papers.bib` file do not have the `<` symbol appearing before the URL. I believe you should be able to test this on your end using the `Deploy site` GitHub action.

If the `_bibliography/papers.bib` file was generated using Zotero or another reference manager, then you may need to remove the `<` symbol under the URL field there before generating the `.bib` file.

By the way, nice lab website!