### PR TITLE
fix: link to classes

### DIFF
--- a/_pages/join.md
+++ b/_pages/join.md
@@ -27,7 +27,7 @@ Please note that all admission decisions are made by the admissions committee.
 ## Existing Purdue Undergraduate/Masters/Doctoral Students
 
 Please email the PI directly with your résumé or CV and a cover letter about why you are interested in working in the lab and your relevant experience.
-It is also recommended to [take a course offered by the PI](/teaching) and express your interest in joining the lab.
+It is also recommended to [take a course offered by the PI](/classes) and express your interest in joining the lab.
 
 ## Diversity and Inclusion
 


### PR DESCRIPTION
The "take a course offered by the PI" link under the ["Joining the CoMMA Lab" page](https://commalab.org/join) currently points to `https://commalab.org/teaching`, which does not seem to exist. Changed this to `https://commalab.org/classes`, which is the actual ["Teaching" page](https://commalab.org/classes/). I hope this is OK.